### PR TITLE
fix: CVE remediation — dompurify XSS (GHSA-h8r8-wccr-v5f2, GHSA-v2wj-7wpq-c8vv)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,7 @@
         "@types/bun": "^1.3.9",
         "bad-words": "^4.0.0",
         "docx": "^9.5.1",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.3.3",
         "file-saver": "^2.0.5",
         "isbot": "^5.1.32",
         "jspdf": "^4.2.0",
@@ -565,7 +565,7 @@
 
     "docx": ["docx@9.6.0", "", { "dependencies": { "@types/node": "^25.2.3", "hash.js": "^1.1.7", "jszip": "^3.10.1", "nanoid": "^5.1.3", "xml": "^1.0.1", "xml-js": "^1.6.8" } }, "sha512-y6EaJJMDvt4P7wgGQB9KsZf4wsRkQMJfkc9LlNufRshggI5BT35hGNkXBCAeEoI3MLMwApKguxzjdqqVcBCqNA=="],
 
-    "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
+    "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,7 +18,7 @@
     "@types/bun": "^1.3.9",
     "bad-words": "^4.0.0",
     "docx": "^9.5.1",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.3.3",
     "file-saver": "^2.0.5",
     "isbot": "^5.1.32",
     "jspdf": "^4.2.0",


### PR DESCRIPTION
Automated CVE remediation by Ona Agent.

## Summary

Bumps `dompurify` from `3.3.1` to `3.3.3` to patch two moderate XSS vulnerabilities reachable in this codebase.

## Vulnerabilities patched

| Advisory | Severity | Description | Affected versions |
|---|---|---|---|
| [GHSA-h8r8-wccr-v5f2](https://github.com/advisories/GHSA-h8r8-wccr-v5f2) | Moderate | Mutation-XSS via re-contextualization | `< 3.3.2` |
| [GHSA-v2wj-7wpq-c8vv](https://github.com/advisories/GHSA-v2wj-7wpq-c8vv) | Moderate (CVSS 6.1) | XSS via namespace confusion | `>= 3.1.3 <= 3.3.1` |

## Reachability

`DOMPurify.sanitize()` is called directly in `packages/frontend/app/utils/editor/functions.ts` (line 32) via `sanitizeText()`, which is invoked when populating the Lexical editor with user resume data. Both CVEs affect this call path.

## Changes

- `packages/frontend/package.json`: `"dompurify": "^3.3.1"` → `"^3.3.3"`
- `bun.lock`: resolved entry updated to `dompurify@3.3.3` with new integrity hash

No code changes required — the `DOMPurify.sanitize()` API is identical across these patch versions.