### PR TITLE
feat(experience): split work history location into city + state

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|shell_command|exec_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/enforce-bun.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/frontend/app/components/Select.tsx
+++ b/packages/frontend/app/components/Select.tsx
@@ -67,11 +67,11 @@ function Select({
         onChange={handleChange}
         onBlur={handleBlur}
         disabled={disabled}
-        className={`${sharedFormControlClass} bg-white text-gray-900 border-gray-300 dark:bg-gray-900 dark:text-white dark:border-gray-600 ${classNames ?? ''} ${
+        className={`${sharedFormControlClass} bg-white text-gray-900 dark:bg-gray-900 dark:text-white ${classNames ?? ''} ${
           disabled
             ? 'opacity-50 cursor-not-allowed bg-gray-100 dark:bg-gray-800'
             : ''
-        } ${isDirty && showError ? 'border-red-500' : ''}`}
+        } ${isDirty && showError ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}`}
       >
         <option
           value=""

--- a/packages/frontend/app/components/Select.tsx
+++ b/packages/frontend/app/components/Select.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useState } from 'react';
+import { sharedFormControlClass } from '../utils/inputTypes';
 import type { FormErrors } from './Input';
 
 type SelectOption = {
@@ -14,6 +15,7 @@ type SelectProps = {
   error?: FormErrors;
   disabled?: boolean;
   classNames?: string;
+  placeholder?: string;
 };
 
 function Select({
@@ -24,6 +26,7 @@ function Select({
   error,
   disabled,
   classNames,
+  placeholder = 'Select an option',
 }: SelectProps) {
   const [isDirty, setIsDirty] = useState(false);
   const [showError, setShowError] = useState(false);
@@ -64,15 +67,24 @@ function Select({
         onChange={handleChange}
         onBlur={handleBlur}
         disabled={disabled}
-        className={`mt-1 block w-full border shadow-sm ${classNames ?? ''} ${
+        className={`${sharedFormControlClass} bg-white text-gray-900 border-gray-300 dark:bg-gray-900 dark:text-white dark:border-gray-600 ${classNames ?? ''} ${
           disabled
             ? 'opacity-50 cursor-not-allowed bg-gray-100 dark:bg-gray-800'
             : ''
         } ${isDirty && showError ? 'border-red-500' : ''}`}
       >
-        <option value="">Select a state</option>
+        <option
+          value=""
+          className="bg-white text-gray-900 dark:bg-gray-900 dark:text-white"
+        >
+          {placeholder}
+        </option>
         {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
+          <option
+            key={opt.value}
+            value={opt.value}
+            className="bg-white text-gray-900 dark:bg-gray-900 dark:text-white"
+          >
             {opt.label}
           </option>
         ))}

--- a/packages/frontend/app/routes/builder/experience.test.ts
+++ b/packages/frontend/app/routes/builder/experience.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { BaseExperienceSchema } from '../../utils/schemas/experience';
+
+const validExperience = {
+  jobId: 'job-1',
+  jobTitle: 'Developer',
+  employer: 'Example Co',
+  city: 'Denver',
+  state: 'CO',
+  startDate: '2024-01',
+  endDate: '2024-06',
+  currentlyEmployed: false,
+};
+
+describe('BaseExperienceSchema', () => {
+  test('accepts valid city and state values independently', () => {
+    const parsed = BaseExperienceSchema.parse(validExperience);
+
+    expect(parsed.city).toBe('Denver');
+    expect(parsed.state).toBe('CO');
+  });
+
+  test('rejects an empty city', () => {
+    const result = BaseExperienceSchema.safeParse({
+      ...validExperience,
+      city: '',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.city).toEqual([
+        'City is required.',
+      ]);
+    }
+  });
+
+  test('rejects an empty state', () => {
+    const result = BaseExperienceSchema.safeParse({
+      ...validExperience,
+      state: '',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.state).toEqual([
+        'State is required.',
+      ]);
+    }
+  });
+});

--- a/packages/frontend/app/routes/builder/experience.tsx
+++ b/packages/frontend/app/routes/builder/experience.tsx
@@ -1,3 +1,4 @@
+import { type ChangeEvent, useCallback, useState } from 'react';
 import {
   data,
   Form,
@@ -6,46 +7,22 @@ import {
   useLoaderData,
   useNavigate,
 } from 'react-router';
-import type { Route } from '../../../.react-router/types/app/+types/root';
 import { z } from 'zod';
+import type { Route } from '../../../.react-router/types/app/+types/root';
 import Button from '../../components/Button';
+import { HeadingWithSubHeading } from '../../components/HeadingWithSubHeading';
 import Input, { type FormErrors } from '../../components/Input';
+import Main from '../../components/Main';
+import Select from '../../components/Select';
+import type { ActionData } from '../../models/Actions';
+import { addQueryParams } from '../../utils/navigation';
+import { BaseExperienceSchema } from '../../utils/schemas/experience';
 import {
   getExperienceDetails,
   getQueuedExperience,
   setQueuedExperience,
 } from '../../utils/user';
-import type { ActionData } from '../../models/Actions';
-import { addQueryParams } from '../../utils/navigation';
-import { type ChangeEvent, useCallback, useState } from 'react';
-import Main from '../../components/Main';
-import { HeadingWithSubHeading } from '../../components/HeadingWithSubHeading';
-
-export const BaseExperienceSchema = z.object({
-  jobId: z.string().min(1),
-  jobTitle: z.string().min(1, 'Job Title is required.'),
-  employer: z.string().min(1, 'Employer is required.'),
-  location: z.string().min(1, 'Location is required.'),
-  startDate: z
-    .string()
-    .min(1, 'Start date is required.')
-    .transform((date) => new Date(date))
-    .refine((date) => !Number.isNaN(date.getTime), {
-      message: 'Invalid state date format.',
-    })
-    .refine((date) => date <= new Date(), {
-      message: 'State date cannot be in the future.',
-    }),
-  endDate: z
-    .string()
-    .transform((date) => (date ? new Date(date) : undefined))
-    .optional()
-    .refine((date) => !date || !Number.isNaN(date.getTime), {
-      message: 'Invalid end date format',
-    }),
-  currentlyEmployed: z.boolean().default(false),
-  details: z.array(z.string()).optional(),
-});
+import { usStates } from '../../utils/usStates';
 
 const ExperienceSchema = BaseExperienceSchema.refine(
   (data) => {
@@ -186,12 +163,20 @@ export default function WorkExperience() {
             defaultValue={prevExperience?.employer}
           />
           <Input
-            label="Location"
+            label="City"
             type="text"
-            id="location"
-            placeholder="Denver, CO"
+            id="city"
+            placeholder="Denver"
             error={errors}
-            defaultValue={prevExperience?.location}
+            defaultValue={prevExperience?.city}
+          />
+          <Select
+            label="State"
+            id="state"
+            options={usStates}
+            placeholder="Select a state"
+            error={errors}
+            defaultValue={prevExperience?.state}
           />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 sm:col-span-2">
             <Input

--- a/packages/frontend/app/routes/builder/experienceSummary.tsx
+++ b/packages/frontend/app/routes/builder/experienceSummary.tsx
@@ -1,6 +1,4 @@
 import { memo } from 'react';
-import Heading from '../../components/Heading';
-import { clearQueuedExperience, getRequiredUserTrait } from '../../utils/user';
 import {
   data,
   Form,
@@ -9,9 +7,12 @@ import {
   useLoaderData,
   useNavigate,
 } from 'react-router';
-import Button from '../../components/Button';
 import type { Route } from '../../+types/root';
+import Button from '../../components/Button';
+import Heading from '../../components/Heading';
 import Main from '../../components/Main';
+import { formatExperienceLocation } from '../../utils/editor/formatters/experience';
+import { clearQueuedExperience, getRequiredUserTrait } from '../../utils/user';
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const url = new URL(request.url);
@@ -65,7 +66,7 @@ function ExperienceSummary() {
                 </span>
                 <Heading level="h2" size="text-2xl" text={e.jobTitle} />
               </div>
-              <em>{e.location}</em>
+              <em>{formatExperienceLocation(e)}</em>
               <span> | </span>
               <em>
                 {e.startDate.getUTCFullYear().toString()}
@@ -73,8 +74,8 @@ function ExperienceSummary() {
                 {e.endDate ? e.endDate.getUTCFullYear() : 'Present'}
               </em>
               <ul className="p-4 list-disc">
-                {e.details?.map((d, index) => (
-                  <li key={`${e.jobId}-detail-${index}`}>{d}</li>
+                {e.details?.map((d) => (
+                  <li key={`${e.jobId}-${d}`}>{d}</li>
                 ))}
               </ul>
             </div>

--- a/packages/frontend/app/routes/builder/finishup.tsx
+++ b/packages/frontend/app/routes/builder/finishup.tsx
@@ -1,13 +1,13 @@
 // app/routes/builder.finish.tsx
-import { redirect, useLoaderData } from 'react-router';
-import { Form } from 'react-router';
+import { Form, redirect, useLoaderData } from 'react-router';
 import type { Route } from '../../../.react-router/types/app/+types/root';
 import Button from '../../components/Button';
-import Heading from '../../components/Heading';
 import EditLink from '../../components/EditLink';
-import { getUser, type User } from '../../utils/user';
-import Main from '../../components/Main';
+import Heading from '../../components/Heading';
 import { HeadingWithSubHeading } from '../../components/HeadingWithSubHeading';
+import Main from '../../components/Main';
+import { formatExperienceLocation } from '../../utils/editor/formatters/experience';
+import { getUser, type User } from '../../utils/user';
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const formData = await request.formData();
@@ -128,7 +128,7 @@ export default function Finish() {
                     </span>
                   </div>
                   <div className="text-sm text-gray-600 dark:text-gray-300">
-                    {job.employer} • {job.location}
+                    {job.employer} • {formatExperienceLocation(job)}
                   </div>
                   {job.details && (
                     <ul className="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-400 list-disc list-inside">

--- a/packages/frontend/app/utils/editor/formatters/experience.test.ts
+++ b/packages/frontend/app/utils/editor/formatters/experience.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'bun:test';
+import { formatExperienceLocation } from './experience';
+
+test('formats experience location as city and state abbreviation', () => {
+  expect(
+    formatExperienceLocation({
+      city: 'Denver',
+      state: 'CO',
+    }),
+  ).toBe('Denver, CO');
+});

--- a/packages/frontend/app/utils/editor/formatters/experience.ts
+++ b/packages/frontend/app/utils/editor/formatters/experience.ts
@@ -1,0 +1,7 @@
+import type { Experience } from './../../user';
+
+export function formatExperienceLocation(
+  experience: Pick<Experience, 'city' | 'state'>,
+): string {
+  return [experience.city, experience.state].filter(Boolean).join(', ');
+}

--- a/packages/frontend/app/utils/editor/functions.ts
+++ b/packages/frontend/app/utils/editor/functions.ts
@@ -1,28 +1,30 @@
-import { Packer, Document } from 'docx';
+import { $createHeadingNode } from '@lexical/rich-text';
+import { Document, Packer } from 'docx';
+import fileSaver from 'file-saver';
 import {
   $createParagraphNode,
   $createTextNode,
   type LexicalEditor,
   type RootNode,
 } from 'lexical';
-import { $createHeadingNode } from '@lexical/rich-text';
 import type { User } from '../user';
-
-import fileSaver from 'file-saver';
 import { $createCustomParagraphNode } from './custom/CustomParagraphNode';
+
 const { saveAs } = fileSaver;
+
 import DOMPurify from 'dompurify';
 import jsPDF from 'jspdf';
+import { formatEducationString } from './formatters/education';
+import { formatExperienceLocation } from './formatters/experience';
+import { formatInfoString } from './formatters/info';
 import {
-  addUserInfo,
-  addSummary,
-  addSkills,
-  addExperience,
   addEducation,
+  addExperience,
+  addSkills,
+  addSummary,
+  addUserInfo,
 } from './pdf/addParts';
 import { generateDocxElements } from './word/addParts';
-import { formatEducationString } from './formatters/education';
-import { formatInfoString } from './formatters/info';
 
 /**
  * Use DOMPurify to sanitize the input text.
@@ -90,7 +92,9 @@ export function populateEditorWithUserData(root: RootNode, userData: User) {
       const jobTitleNode = $createHeadingNode('h3');
       jobTitleNode.append(
         $createTextNode(
-          sanitizeText(`${job.jobTitle} | ${job.employer} | ${job.location}`),
+          sanitizeText(
+            `${job.jobTitle} | ${job.employer} | ${formatExperienceLocation(job)}`,
+          ),
         ),
       );
       root.append(jobTitleNode);

--- a/packages/frontend/app/utils/editor/pdf/addParts.ts
+++ b/packages/frontend/app/utils/editor/pdf/addParts.ts
@@ -1,6 +1,7 @@
 import type jsPDF from 'jspdf';
 import type { User } from '../../user';
 import { formatEducationString } from '../formatters/education';
+import { formatExperienceLocation } from '../formatters/experience';
 import { formatInfoString } from '../formatters/info';
 
 /**
@@ -139,7 +140,7 @@ export function addExperience(
       doc.setFontSize(12);
       doc.setFont(defaultFont, 'bold');
       doc.text(
-        `${job.jobTitle} | ${job.employer} | ${job.location}`,
+        `${job.jobTitle} | ${job.employer} | ${formatExperienceLocation(job)}`,
         14,
         currentY,
       );

--- a/packages/frontend/app/utils/editor/word/addParts.ts
+++ b/packages/frontend/app/utils/editor/word/addParts.ts
@@ -1,7 +1,8 @@
-import { Paragraph, HeadingLevel, AlignmentType, TextRun } from 'docx';
+import { AlignmentType, HeadingLevel, Paragraph, TextRun } from 'docx';
 import fileSaver from 'file-saver';
 import type { User } from '../../user';
 import { formatEducationString } from '../formatters/education';
+import { formatExperienceLocation } from '../formatters/experience';
 import { formatInfoString } from '../formatters/info';
 
 /**
@@ -108,7 +109,7 @@ function generateExperienceElements(userData: User) {
     for (const job of userData.experience) {
       elements.push(
         new Paragraph({
-          text: `${job.jobTitle} | ${job.employer} | ${job.location}`,
+          text: `${job.jobTitle} | ${job.employer} | ${formatExperienceLocation(job)}`,
           heading: HeadingLevel.HEADING_3,
         }),
       );

--- a/packages/frontend/app/utils/inputTypes.ts
+++ b/packages/frontend/app/utils/inputTypes.ts
@@ -1,11 +1,12 @@
-const defaultShape = 'mt-1 block w-full border shadow-sm';
+export const sharedFormControlClass =
+  'mt-1 block w-full border shadow-sm px-3 py-3 text-lg';
 
 export const inputTypes = {
-  text: `${defaultShape}`,
-  email: `${defaultShape}`,
-  month: `${defaultShape}`,
-  number: `${defaultShape}`,
-  tel: `${defaultShape}`,
+  text: sharedFormControlClass,
+  email: sharedFormControlClass,
+  month: sharedFormControlClass,
+  number: sharedFormControlClass,
+  tel: sharedFormControlClass,
 } as const;
 
 export type InputTypes = typeof inputTypes;

--- a/packages/frontend/app/utils/schemas/experience.ts
+++ b/packages/frontend/app/utils/schemas/experience.ts
@@ -10,7 +10,7 @@ export const BaseExperienceSchema = z.object({
     .string()
     .min(1, 'Start date is required.')
     .transform((date) => new Date(date))
-    .refine((date) => !Number.isNaN(date.getTime), {
+    .refine((date) => !Number.isNaN(date.getTime()), {
       message: 'Invalid start date format.',
     })
     .refine((date) => date <= new Date(), {
@@ -20,7 +20,7 @@ export const BaseExperienceSchema = z.object({
     .string()
     .transform((date) => (date ? new Date(date) : undefined))
     .optional()
-    .refine((date) => !date || !Number.isNaN(date.getTime), {
+    .refine((date) => !date || !Number.isNaN(date.getTime()), {
       message: 'Invalid end date format',
     }),
   currentlyEmployed: z.boolean().default(false),

--- a/packages/frontend/app/utils/schemas/experience.ts
+++ b/packages/frontend/app/utils/schemas/experience.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const BaseExperienceSchema = z.object({
+  jobId: z.string().min(1),
+  jobTitle: z.string().min(1, 'Job Title is required.'),
+  employer: z.string().min(1, 'Employer is required.'),
+  city: z.string().min(1, 'City is required.'),
+  state: z.string().min(1, 'State is required.'),
+  startDate: z
+    .string()
+    .min(1, 'Start date is required.')
+    .transform((date) => new Date(date))
+    .refine((date) => !Number.isNaN(date.getTime), {
+      message: 'Invalid start date format.',
+    })
+    .refine((date) => date <= new Date(), {
+      message: 'Start date cannot be in the future.',
+    }),
+  endDate: z
+    .string()
+    .transform((date) => (date ? new Date(date) : undefined))
+    .optional()
+    .refine((date) => !date || !Number.isNaN(date.getTime), {
+      message: 'Invalid end date format',
+    }),
+  currentlyEmployed: z.boolean().default(false),
+  details: z.array(z.string()).optional(),
+});

--- a/packages/frontend/app/utils/user.ts
+++ b/packages/frontend/app/utils/user.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
-import { BaseExperienceSchema } from '../routes/builder/experience';
 import { BaseEducationSchema } from '../routes/builder/education';
 import { PersonalInfoSchema } from '../routes/builder/info';
 import { SkillsSchema } from '../routes/builder/skills';
 import { SummarySchema } from '../routes/builder/summary';
+import { BaseExperienceSchema } from './schemas/experience';
 
 const PartialPersonalInfo = PersonalInfoSchema;
 const PartialExperienceSchema = BaseExperienceSchema;


### PR DESCRIPTION
## Summary
- Replaces the single Work History `location` field with separate City input and State `<select>` (backed by `usStates`), extracts the experience zod schema into `utils/schemas/experience.ts`, and routes display through a shared `formatExperienceLocation` helper used by the summary view, finish-up review, and PDF / Word / Lexical editor renderers.
- Promotes `Select` to a reusable form component (with `placeholder` prop) and consolidates the form-control class onto a shared `sharedFormControlClass` constant in `inputTypes.ts`.
- Adds unit tests for `BaseExperienceSchema` (city/state validation) and `formatExperienceLocation`, plus a small drive-by fix for a `noArrayIndexKey` in `experienceSummary.tsx`.

## Test plan
- [x] `bun test` (22 passing)
- [ ] Manual: walk the builder flow — enter a job, verify city + state persist, summary/finish-up/PDF/Word output show "City, ST"
- [ ] Manual: edit an existing job and confirm prior city/state defaults are restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)